### PR TITLE
Improve type hinting

### DIFF
--- a/python/typst/__init__.pyi
+++ b/python/typst/__init__.pyi
@@ -8,21 +8,20 @@ def compile(
     input: PathLike,
     output: PathLike,
     root: Optional[PathLike] = None,
-    font_paths: Optional[List[PathLike]] = None,
+    font_paths: List[PathLike] = [],
 ) -> None: ...
-
 @overload
 def compile(
     input: PathLike,
     output: None = None,
     root: Optional[PathLike] = None,
-    font_paths: Optional[List[PathLike]] = None,
+    font_paths: List[PathLike] = [],
 ) -> bytes: ...
 def compile(
     input: PathLike,
     output: Optional[PathLike] = None,
     root: Optional[PathLike] = None,
-    font_paths: Optional[List[PathLike]] = None,
+    font_paths: List[PathLike] = [],
 ) -> Optional[bytes]:
     """Compile a Typst project.
 
@@ -31,7 +30,7 @@ def compile(
         output (Optional[PathLike], optional): Path to save the compiled file.
         Allowed extensions are `.pdf`, `.svg` and `.png`
         root (Optional[PathLike], optional): Root path for the Typst project.
-        font_paths (Optional[List[PathLike]], optional): Folders with fonts.
+        font_paths (List[PathLike]): Folders with fonts.
 
     Returns:
         Optional[bytes]: Return the compiled file as `bytes` if output is `None`.

--- a/python/typst/__init__.pyi
+++ b/python/typst/__init__.pyi
@@ -18,11 +18,21 @@ def compile(
     root: Optional[PathLike] = None,
     font_paths: Optional[List[PathLike]] = None,
 ) -> bytes: ...
-
-
 def compile(
     input: PathLike,
     output: Optional[PathLike] = None,
     root: Optional[PathLike] = None,
     font_paths: Optional[List[PathLike]] = None,
-) -> Optional[bytes]: ...
+) -> Optional[bytes]:
+    """Compile a Typst project.
+
+    Args:
+        input (PathLike): Projet's main .typ file.
+        output (Optional[PathLike], optional): Path to save the compiled file.
+        Allowed extensions are `.pdf`, `.svg` and `.png`
+        root (Optional[PathLike], optional): Root path for the Typst project.
+        font_paths (Optional[List[PathLike]], optional): Folders with fonts.
+
+    Returns:
+        Optional[bytes]: Return the compiled file as `bytes` if output is `None`.
+    """

--- a/python/typst/__init__.pyi
+++ b/python/typst/__init__.pyi
@@ -1,11 +1,28 @@
 import pathlib
-from typing import List, Optional, TypeVar
+from typing import List, Optional, TypeVar, overload
 
 PathLike = TypeVar("PathLike", str, pathlib.Path)
+
+@overload
+def compile(
+    input: PathLike,
+    output: PathLike,
+    root: Optional[PathLike] = None,
+    font_paths: Optional[List[PathLike]] = None,
+) -> None: ...
+
+@overload
+def compile(
+    input: PathLike,
+    output: None = None,
+    root: Optional[PathLike] = None,
+    font_paths: Optional[List[PathLike]] = None,
+) -> bytes: ...
+
 
 def compile(
     input: PathLike,
     output: Optional[PathLike] = None,
     root: Optional[PathLike] = None,
-    font_paths: List[PathLike] = [],
+    font_paths: Optional[List[PathLike]] = None,
 ) -> Optional[bytes]: ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,13 @@ fn resources_path(py: Python<'_>, package: &str) -> PyResult<PathBuf> {
 
 /// Compile a typst document to PDF
 #[pyfunction]
-#[pyo3(signature = (input, output = None, root = None, font_paths = None))]
+#[pyo3(signature = (input, output = None, root = None, font_paths = Vec::new()))]
 fn compile(
     py: Python<'_>,
     input: PathBuf,
     output: Option<PathBuf>,
     root: Option<PathBuf>,
-    font_paths: Option<Vec<PathBuf>>,
+    font_paths: Vec<PathBuf>,
 ) -> PyResult<PyObject> {
     let input = input.canonicalize()?;
     let root = if let Some(root) = root {
@@ -71,10 +71,7 @@ fn compile(
             }
         }
         let mut world = SystemWorld::new(root, input)
-            .font_paths(match font_paths {
-                Some(font_paths) => font_paths,
-                None => Vec::new(),
-            })
+            .font_paths(font_paths)
             .font_files(default_fonts)
             .build()
             .map_err(|msg| PyRuntimeError::new_err(msg.to_string()))?;


### PR DESCRIPTION
Hello @messense!

Thanks for bringing Typst to Python! 

As I was playing with it, I noticed two problems:

1. The type-hinting of the compile method can be improved to show different behaviors of the function:
- If `output` is `None` then the function returns `bytes`
- Else, the file is written to disk and `None` is returned.
2. The `font_paths` default value is a mutable empty list. It's considered bad practice in pure Python ([as described here](https://nikos7am.com/posts/mutable-default-arguments/)). I'm not sure about Python bound to rust via PyO3. 🤔 

Anyway, I suggest overloading the function compile to solve the first problem and using `None` as the default value for `font_paths`. This `None` will be replaced with a new Vec in Rust.