### PR TITLE
Fix borrowed variable `&abs`

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -116,7 +116,7 @@ impl<'a> codespan_reporting::files::Files<'a> for SystemWorld {
             // Try to express the path relative to the working directory.
             vpath
                 .resolve(self.root())
-                .and_then(|abs| pathdiff::diff_paths(&abs, self.workdir()))
+                .and_then(|abs| pathdiff::diff_paths(abs, self.workdir()))
                 .as_deref()
                 .unwrap_or_else(|| vpath.as_rootless_path())
                 .to_string_lossy()


### PR DESCRIPTION
Minimum fix of borrowed variable that I found using [cargo clippy](https://github.com/rust-lang/rust-clippy)