### PR TITLE
Fix typos

### DIFF
--- a/python/typst/__init__.pyi
+++ b/python/typst/__init__.pyi
@@ -26,7 +26,7 @@ def compile(
 ) -> Optional[bytes]:
     """Compile a Typst project.
     Args:
-        input (PathLike): Projet's main .typ file.
+        input (PathLike): Project's main .typ file.
         output (Optional[PathLike], optional): Path to save the compiled file.
         Allowed extensions are `.pdf`, `.svg` and `.png`
         root (Optional[PathLike], optional): Root path for the Typst project.

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -65,7 +65,7 @@ impl FontSearcher {
             let path = match &face.source {
                 Source::File(path) | Source::SharedFile(path, _) => path,
                 // We never add binary sources to the database, so there
-                // shouln't be any.
+                // shouldn't be any.
                 Source::Binary(_) => continue,
             };
 


### PR DESCRIPTION
Found via `typos --hidden --format brief` and `codespell -L crate`