### PR TITLE
Change world to static lifetime to avoid reinitialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ fn resources_path(py: Python<'_>, package: &str) -> PyResult<PathBuf> {
     }
 }
 
-/// Create a new world.
+/// Compile a typst document
 #[pyfunction]
 #[pyo3(signature = (input, output = None, root = None, font_paths = Vec::new(), format = None, ppi = None))]
 fn compile(


### PR DESCRIPTION
Change world to a thread-safe static variable to avoid reinitialization, preventing multiple times loading font files. This can reduce the average time overhead of rendering PNG images to a few milliseconds.

Preceding dependency: https://github.com/messense/typst-py/pull/17