### PR TITLE
feat: export multiple pages for png and svg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "citationberg"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82108f2b676c954076d2e5044f19a6a03887b24bd42804f322e0650d13035899"
+checksum = "d259fe9fd78ffa05a119581d20fddb50bfba428311057b12741ffb9015123d0b"
 dependencies = [
  "quick-xml",
  "serde",
@@ -621,9 +621,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hayagriva"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2e670de5191df083ddd112cd253049f8213277ccf0c15e18a8bf10e6c666cc"
+checksum = "1d0d20c98b77b86ce737876b2a1653e2e6abbeee84afbb39d72111091191c97a"
 dependencies = [
  "biblatex",
  "ciborium",
@@ -2202,9 +2202,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typst"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ce6533a33d2cc4b5eba6b009b862e75c8f9146a584f84ca154c94463e43993"
+checksum = "12492297d20937494f0143ae50ef339e5fd3d927b4096af1c52fe73fb9c5fa9a"
 dependencies = [
  "az",
  "bitflags 2.4.1",
@@ -2264,15 +2264,15 @@ dependencies = [
 
 [[package]]
 name = "typst-assets"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13f85360328da54847dd7fefaf272dfa5b6d1fdeb53f32938924c39bf5b2c6c"
+checksum = "2b3061f8d268e8eec7481c9ab24540455cb4912983c49aae38fa6e8bf8ef4d9c"
 
 [[package]]
 name = "typst-macros"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e48fdd6dabf48a0e595960aaef6ae43dac7d243e8c1c6926a0787d5b8a9ba7"
+checksum = "e5a0fdfd46b4920b0f8e4215e5b8438c737e8bc3498a681ea59b0130228363fc"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2282,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "typst-pdf"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c27957bbe3e17b961746a7ddf6f0831479674331457680bb8e3b84f7b83bd58"
+checksum = "54f743b64330e576d31b2108626490ae1fbd7fb4bb28307536ceff3227a4e0d5"
 dependencies = [
  "base64 0.22.0",
  "bytemuck",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "typst-py"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "codespan-reporting",
@@ -2335,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "typst-render"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7bcbc9a824c5e4d61327ec100e570d7ba03e3a29dcdb0a9736024a9b0e86594"
+checksum = "6f122fa9fde65683fde5ac444ecfbdc1a5ad4822dbaa537fe278345bb6b6ad7e"
 dependencies = [
  "bytemuck",
  "comemo",
@@ -2356,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "typst-svg"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9b13b1cfea54220435a93b11f63bee12e6af6fefd3d6bf37efc46ba1f514e"
+checksum = "cef4e3640269c81ceafb09e0afe8374b2c25890e82c013550a1d25a2b9aae23b"
 dependencies = [
  "base64 0.22.0",
  "comemo",
@@ -2374,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "typst-syntax"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367d86bf18f0363146bea1ea76fad19b54458695fdfad5e74ead3ede574b75fe"
+checksum = "e3db69f2f41613b1ff6edbec44fd7dc524137f099ee36c46f560cedeaadb40c4"
 dependencies = [
  "comemo",
  "ecow",
@@ -2391,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "typst-timing"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2629933cde6f299c43627b90c83bb006cb906c56cc5dec7324f0a5017d5fd8"
+checksum = "5b58e17192bcacb2a39aace6d3eece70f008b2949ce384ac501a58357fafee67"
 dependencies = [
  "parking_lot",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typst-py"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Python binding to typst"
 license = "Apache-2.0"
@@ -29,10 +29,10 @@ pyo3 = { version = "0.21.2", features = ["abi3-py37"] }
 same-file = "1"
 siphasher = "1.0"
 tar = "0.4"
-typst ="0.11.0"
-typst-pdf = "0.11.0"
-typst-svg = "0.11.0"
-typst-render = "0.11.0"
+typst ="0.11.1"
+typst-pdf = "0.11.1"
+typst-svg = "0.11.1"
+typst-render = "0.11.1"
 ureq = { version = "2", default-features = false, features = [
     "gzip",
     "socks-proxy",

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ pdf_bytes = typst.compile("hello.typ")
 # Also for svg
 svg_bytes = typst.compile("hello.typ", format="svg")
 
+# For multi-page export (the template is the same as the typst cli)
+images = typst.compile("hello.typ", output="hello{n}.png", format="png")
+
 # Or use Compiler class to avoid reinitialization
 compiler = typst.Compiler("hello.typ")
 compiler.compile(format="png", ppi=144.0)

--- a/python/typst/__init__.pyi
+++ b/python/typst/__init__.pyi
@@ -1,5 +1,5 @@
 import pathlib
-from typing import List, Optional, TypeVar, overload, Dict
+from typing import List, Optional, TypeVar, overload, Dict, Union
 
 PathLike = TypeVar("PathLike", str, pathlib.Path)
 
@@ -9,7 +9,7 @@ class Compiler:
         input: PathLike,
         root: Optional[PathLike] = None,
         font_paths: List[PathLike] = [],
-        sys_inputs: Dict[str, str] = {}
+        sys_inputs: Dict[str, str] = {},
     ) -> None:
         """Initialize a Typst compiler.
         Args:
@@ -18,12 +18,13 @@ class Compiler:
             font_paths (List[PathLike]): Folders with fonts.
             sys_inputs (Dict[str, str]): string key-value pairs to be passed to the document via sys.inputs
         """
+
     def compile(
         self,
         output: Optional[PathLike] = None,
         format: Optional[str] = None,
         ppi: Optional[float] = None,
-    ) -> Optional[bytes]:
+    ) -> Optional[Union[bytes, List[bytes]]]:
         """Compile a Typst project.
         Args:
             output (Optional[PathLike], optional): Path to save the compiled file.
@@ -32,7 +33,7 @@ class Compiler:
             Allowed values are `pdf`, `svg` and `png`.
             ppi (Optional[float]): Pixels per inch for PNG output, defaults to 144.
         Returns:
-            Optional[bytes]: Return the compiled file as `bytes` if output is `None`.
+            Optional[Union[bytes, List[bytes]]]: Return the compiled file as `bytes` if output is `None`.
         """
 
 @overload
@@ -43,7 +44,7 @@ def compile(
     font_paths: List[PathLike] = [],
     format: Optional[str] = None,
     ppi: Optional[float] = None,
-    sys_inputs: Dict[str, str] = {}
+    sys_inputs: Dict[str, str] = {},
 ) -> None: ...
 @overload
 def compile(
@@ -53,7 +54,7 @@ def compile(
     font_paths: List[PathLike] = [],
     format: Optional[str] = None,
     ppi: Optional[float] = None,
-    sys_inputs: Dict[str, str] = {}
+    sys_inputs: Dict[str, str] = {},
 ) -> bytes: ...
 def compile(
     input: PathLike,
@@ -62,8 +63,8 @@ def compile(
     font_paths: List[PathLike] = [],
     format: Optional[str] = None,
     ppi: Optional[float] = None,
-    sys_inputs: Dict[str, str] = {}
-) -> Optional[bytes]:
+    sys_inputs: Dict[str, str] = {},
+) -> Optional[Union[bytes, List[bytes]]]:
     """Compile a Typst project.
     Args:
         input (PathLike): Project's main .typ file.
@@ -76,5 +77,5 @@ def compile(
         ppi (Optional[float]): Pixels per inch for PNG output, defaults to 144.
         sys_inputs (Dict[str, str]): string key-value pairs to be passed to the document via sys.inputs
     Returns:
-        Optional[bytes]: Return the compiled file as `bytes` if output is `None`.
+        Optional[Union[bytes, List[bytes]]]: Return the compiled file as `bytes` if output is `None`.
     """

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -15,13 +15,8 @@ use crate::world::SystemWorld;
 type CodespanResult<T> = Result<T, CodespanError>;
 type CodespanError = codespan_reporting::files::Error;
 
-pub enum ImageBuffer {
-    Single(Vec<u8>),
-    Multi(Vec<Vec<u8>>),
-}
-
 impl SystemWorld {
-    pub fn compile(&mut self, format: Option<&str>, ppi: Option<f32>) -> StrResult<ImageBuffer> {
+    pub fn compile(&mut self, format: Option<&str>, ppi: Option<f32>) -> StrResult<Vec<Vec<u8>>> {
         // Reset everything and ensure that the main file is present.
         self.reset();
         self.source(self.main()).map_err(|err| err.to_string())?;
@@ -35,17 +30,9 @@ impl SystemWorld {
             Ok(document) => {
                 // Assert format is "pdf" or "png" or "svg"
                 match format.unwrap_or("pdf").to_ascii_lowercase().as_str() {
-                    "pdf" => Ok(ImageBuffer::Single(export_pdf(&document, self)?)),
-                    "png" => Ok(ImageBuffer::Multi(export_image(
-                        &document,
-                        ImageExportFormat::Png,
-                        ppi,
-                    )?)),
-                    "svg" => Ok(ImageBuffer::Multi(export_image(
-                        &document,
-                        ImageExportFormat::Svg,
-                        ppi,
-                    )?)),
+                    "pdf" => Ok(vec![export_pdf(&document, self)?]),
+                    "png" => Ok(export_image(&document, ImageExportFormat::Png, ppi)?),
+                    "svg" => Ok(export_image(&document, ImageExportFormat::Svg, ppi)?),
                     fmt => Err(eco_format!("unknown format: {fmt}")),
                 }
             }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -15,8 +15,13 @@ use crate::world::SystemWorld;
 type CodespanResult<T> = Result<T, CodespanError>;
 type CodespanError = codespan_reporting::files::Error;
 
+pub enum ImageBuffer {
+    Single(Vec<u8>),
+    Multi(Vec<Vec<u8>>),
+}
+
 impl SystemWorld {
-    pub fn compile(&mut self, format: Option<&str>, ppi: Option<f32>) -> StrResult<Vec<u8>> {
+    pub fn compile(&mut self, format: Option<&str>, ppi: Option<f32>) -> StrResult<ImageBuffer> {
         // Reset everything and ensure that the main file is present.
         self.reset();
         self.source(self.main()).map_err(|err| err.to_string())?;
@@ -30,9 +35,17 @@ impl SystemWorld {
             Ok(document) => {
                 // Assert format is "pdf" or "png" or "svg"
                 match format.unwrap_or("pdf").to_ascii_lowercase().as_str() {
-                    "pdf" => Ok(export_pdf(&document, self)?),
-                    "png" => Ok(export_image(&document, ImageExportFormat::Png, ppi)?),
-                    "svg" => Ok(export_image(&document, ImageExportFormat::Svg, ppi)?),
+                    "pdf" => Ok(ImageBuffer::Single(export_pdf(&document, self)?)),
+                    "png" => Ok(ImageBuffer::Multi(export_image(
+                        &document,
+                        ImageExportFormat::Png,
+                        ppi,
+                    )?)),
+                    "svg" => Ok(ImageBuffer::Multi(export_image(
+                        &document,
+                        ImageExportFormat::Svg,
+                        ppi,
+                    )?)),
                     fmt => Err(eco_format!("unknown format: {fmt}")),
                 }
             }
@@ -68,26 +81,28 @@ enum ImageExportFormat {
     Svg,
 }
 
-/// Export the first frame to PNG or SVG.
+/// Export the frames to PNGs or SVGs.
 fn export_image(
     document: &Document,
     fmt: ImageExportFormat,
     ppi: Option<f32>,
-) -> StrResult<Vec<u8>> {
-    // Find the first frame
-    let frame = &document.pages.first().unwrap().frame;
-    match fmt {
-        ImageExportFormat::Png => {
-            let pixmap = typst_render::render(frame, ppi.unwrap_or(144.0) / 72.0, Color::WHITE);
-            pixmap
-                .encode_png()
-                .map_err(|err| eco_format!("failed to write PNG file ({err})"))
-        }
-        ImageExportFormat::Svg => {
-            let svg = typst_svg::svg(frame);
-            Ok(svg.as_bytes().to_vec())
-        }
+) -> StrResult<Vec<Vec<u8>>> {
+    let mut buffers = Vec::new();
+    for page in &document.pages {
+        let buffer = match fmt {
+            ImageExportFormat::Png => {
+                typst_render::render(&page.frame, ppi.unwrap_or(144.0) / 72.0, Color::WHITE)
+                    .encode_png()
+                    .map_err(|err| eco_format!("failed to write PNG file ({err})"))?
+            }
+            ImageExportFormat::Svg => {
+                let svg = typst_svg::svg(&page.frame);
+                svg.as_bytes().to_vec()
+            }
+        };
+        buffers.push(buffer);
     }
+    Ok(buffers)
 }
 
 /// Format diagnostic messages.\


### PR DESCRIPTION
Base on #33.

1. Automatic format detection: we no longer need `typst.compile("hello.typ", output="hello.png", format="png")`; instead, we only need `typst.compile("hello.typ", output="hello.png")`.
2. Provide multi-page export for PNG and SVG, for example, `typst.compile("hello.typ", output="hello{n}.png")` can export multiple files, consistent with the `typst compile` command. Additionally, for single-page output, `typst.compile("hello.typ", format="png")` returns bytes to maintain compatibility, while for multi-page output, it returns a list of bytes.