### PR TITLE
add `pdf-standards` option

### DIFF
--- a/python/typst/__init__.pyi
+++ b/python/typst/__init__.pyi
@@ -10,6 +10,7 @@ class Compiler:
         root: Optional[PathLike] = None,
         font_paths: List[PathLike] = [],
         sys_inputs: Dict[str, str] = {},
+        pdf_standards: Optional[Union[Literal["1.7", "a-2b"], List[Literal["1.7", "a-2b"]]]] = []
     ) -> None:
         """Initialize a Typst compiler.
         Args:
@@ -62,6 +63,7 @@ def compile(
     format: Optional[Literal["pdf", "svg", "png"]] = None,
     ppi: Optional[float] = None,
     sys_inputs: Dict[str, str] = {},
+    pdf_standards: Optional[Union[Literal["1.7", "a-2b"], List[Literal["1.7", "a-2b"]]]] = []
 ) -> None: ...
 @overload
 def compile(
@@ -72,6 +74,7 @@ def compile(
     format: Optional[Literal["pdf", "svg", "png"]] = None,
     ppi: Optional[float] = None,
     sys_inputs: Dict[str, str] = {},
+    pdf_standards: Optional[Union[Literal["1.7", "a-2b"], List[Literal["1.7", "a-2b"]]]] = []
 ) -> bytes: ...
 def compile(
     input: PathLike,
@@ -81,6 +84,7 @@ def compile(
     format: Optional[Literal["pdf", "svg", "png"]] = None,
     ppi: Optional[float] = None,
     sys_inputs: Dict[str, str] = {},
+    pdf_standards: Optional[Union[Literal["1.7", "a-2b"], List[Literal["1.7", "a-2b"]]]] = []
 ) -> Optional[Union[bytes, List[bytes]]]:
     """Compile a Typst project.
     Args:


### PR DESCRIPTION
Adds support for the `pdf-standards` option of typst 0.12

Closes #67