### PR TITLE
Adds more project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,14 @@ dynamic = ["version"]
 dependencies = []
 license = "Apache-2.0"
 license-files = ["LICENSE"]
+readme = "README.md"
+
+[project.urls]
+
+Homepage = "https://github.com/messense/typst-py/"
+Repository = "https://github.com/messense/typst-py"
+Readme = "https://github.com/messense/typst-py/blob/main/README.md"
+Documentation = "https://github.com/messense/typst-py/blob/main/README.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
I noticed that the PyPI page for this project is quite bare despite you having all the things in the repository.

<img width="1276" height="900" alt="image" src="https://github.com/user-attachments/assets/9d5d4e8f-4f2d-4137-ae48-9a9f37c6750d" />

I am fairly certain that you just need to add a few more items to the `pyproject.toml` to ensure that PyPI can find them easily. So that is what  have done here - provide project URLs and Readme in `pyproject.toml`.