### PR TITLE
feat: more reusable compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ svg_bytes = typst.compile("hello.typ", format="svg")
 images = typst.compile("hello.typ", output="hello{n}.png", format="png")
 
 # Or use Compiler class to avoid reinitialization
-compiler = typst.Compiler("hello.typ")
-compiler.compile(format="png", ppi=144.0)
+compiler = typst.Compiler()
+compiler.compile(input="hello.typ", format="png", ppi=144.0)
 
 # Query something
 import json

--- a/python/typst/__init__.pyi
+++ b/python/typst/__init__.pyi
@@ -66,7 +66,7 @@ class Fonts:
 class Compiler:
     def __init__(
         self,
-        input: Input,
+        input: Optional[Input] = None,
         root: Optional[PathLike] = None,
         font_paths: Union[Fonts, List[Input]] = [],
         ignore_system_fonts: bool = False,
@@ -78,7 +78,7 @@ class Compiler:
     ) -> None:
         """Initialize a Typst compiler.
         Args:
-            input: .typ file bytes or path to project's main .typ file.
+            input: Optional .typ file bytes or path to project's main .typ file. Defaults to an empty in-memory document when omitted.
             root (Optional[PathLike], optional): Root path for the Typst project.
             font_paths (Union[Fonts, List[Input]]): Folders with fonts.
             ignore_system_fonts (bool): Ignore system fonts.
@@ -88,12 +88,14 @@ class Compiler:
 
     def compile(
         self,
+        input: Optional[Input] = None,
         output: Optional[Input] = None,
         format: Optional[OutputFormat] = None,
         ppi: Optional[float] = None,
     ) -> Optional[Union[bytes, List[bytes]]]:
         """Compile a Typst project.
         Args:
+            input: Optional .typ file bytes or path to compile for this invocation.
             output (Optional[PathLike], optional): Path to save the compiled file.
             Allowed extensions are `.pdf`, `.svg` and `.png`
             format (Optional[str]): Output format.
@@ -105,12 +107,14 @@ class Compiler:
 
     def compile_with_warnings(
         self,
+        input: Optional[Input] = None,
         output: Optional[Input] = None,
         format: Optional[OutputFormat] = None,
         ppi: Optional[float] = None,
     ) -> Tuple[Optional[Union[bytes, List[bytes]]], List[TypstWarning]]:
         """Compile a Typst project and return both result and warnings.
         Args:
+            input: Optional .typ file bytes or path to compile for this invocation.
             output (Optional[PathLike], optional): Path to save the compiled file.
             Allowed extensions are `.pdf`, `.svg` and `.png`
             format (Optional[str]): Output format.


### PR DESCRIPTION
# My Summary

- This allows the `Compiler` class to be instantiated without an input
- `Compiler.compile()` can now be called with an `input`, thus allowing the compiler instance to be reused across different documents. I have to believe that this was the original intent of this class, but implementation was not finished – just being able to recompile the same source for different formats does not seem all that useful
- Some internal changes, most notably a new `FileId` is not consumed for every compilation. These are finite within the process (that is, even across `Compiler` instantiations) and only up to $2^{16}$ of them are available. Previously time `compile` was called, at least one FileId was consumed.
- Massive performance enhancement as a result: about 10000x when the input is not changed (largely thanks to memoisation in Typst), but also about 250x when inputs are changed

I think it would be nice if a new release could be cut with this change.

# LLM Summary:
This pull request refactors the initialization and input handling of the `Compiler` class to support dynamic input changes and improve usability. The main enhancement is allowing the `Compiler` to be instantiated without an initial input, enabling reuse of the same compiler instance for multiple compilations with different inputs.

**Core API improvements:**

* The `Compiler` class can now be initialized without an input, defaulting to an empty in-memory document. The `input` parameter for both initialization and compilation methods is now optional, allowing users to set or change the input per compilation. [[1]](diffhunk://#diff-fa23b39694aad2ea4d1dd643a2e6760985205b8cfcfac745121a1c5a41e5e5a6L69-R69) [[2]](diffhunk://#diff-fa23b39694aad2ea4d1dd643a2e6760985205b8cfcfac745121a1c5a41e5e5a6L81-R81) [[3]](diffhunk://#diff-fa23b39694aad2ea4d1dd643a2e6760985205b8cfcfac745121a1c5a41e5e5a6R91-R98) [[4]](diffhunk://#diff-fa23b39694aad2ea4d1dd643a2e6760985205b8cfcfac745121a1c5a41e5e5a6R110-R117)
* The Rust backend (`src/lib.rs`) adds logic to handle dynamic input switching, including helper methods to update the compiler's input and reset compilation state. This enables the same compiler instance to be reused for multiple documents. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R226-R234) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L314-R338) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L359-R381) [[4]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L430-R454)

**Internal implementation changes:**

* The `SystemWorld` struct and related logic in `src/world.rs` are updated to support switching between file and in-memory (bytes) inputs, with new methods for configuring input and managing slots for document sources. [[1]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R28-R29) [[2]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R91-R100) [[3]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R188) [[4]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R210-R218) [[5]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R261-R269) [[6]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R304-R331)
---

**API and usability improvements**
1. Allow `Compiler` to be initialized without an input, defaulting to an empty document, and make input optional for compilation methods. [[1]](diffhunk://#diff-fa23b39694aad2ea4d1dd643a2e6760985205b8cfcfac745121a1c5a41e5e5a6L69-R69) [[2]](diffhunk://#diff-fa23b39694aad2ea4d1dd643a2e6760985205b8cfcfac745121a1c5a41e5e5a6L81-R81) [[3]](diffhunk://#diff-fa23b39694aad2ea4d1dd643a2e6760985205b8cfcfac745121a1c5a41e5e5a6R91-R98) [[4]](diffhunk://#diff-fa23b39694aad2ea4d1dd643a2e6760985205b8cfcfac745121a1c5a41e5e5a6R110-R117)
2. Allow `Compiler.compile()` to take an input, thus making it reusable

**Rust backend and internal logic**
3. Add logic to `Compiler` and `SystemWorld` for dynamic input switching, including helper methods for input configuration and slot management. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R226-R234) [[2]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R28-R29) [[3]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R91-R100) [[4]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R188) [[5]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R210-R218) [[6]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R261-R269) [[7]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R304-R331)

Fixes: #137 