### PR TITLE
Add font discovery methods to Fonts class and introduce FontInfo

### DIFF
--- a/python/typst/__init__.pyi
+++ b/python/typst/__init__.pyi
@@ -56,6 +56,16 @@ class TypstWarning(UserWarning):
         trace: Optional[List[str]] = None,
     ) -> None: ...
 
+class FontInfo:
+    """Immutable information about a single font variant."""
+
+    family: str
+    style: str
+    weight: int
+    stretch: float
+    path: Optional[str]
+    index: int
+
 class Fonts:
     def __init__(
         self,
@@ -63,6 +73,8 @@ class Fonts:
         include_embedded_fonts: bool = True,
         font_paths: List[Input] = [],
     ) -> None: ...
+    def fonts(self) -> List["FontInfo"]: ...
+    def families(self) -> List[str]: ...
 
 class Compiler:
     def __init__(

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,0 +1,98 @@
+import pytest
+import pathlib
+
+import typst
+
+
+# Fixtures
+@pytest.fixture
+def hello_typ_path():
+    return pathlib.Path("tests/hello.typ")
+
+
+# typst.Fonts tests
+def test_fonts_default():
+    fonts = typst.Fonts()
+    assert fonts is not None
+
+
+def test_fonts_no_system_fonts():
+    fonts = typst.Fonts(include_system_fonts=False)
+    assert fonts is not None
+
+
+def test_fonts_no_embedded_fonts():
+    fonts = typst.Fonts(include_embedded_fonts=False)
+    assert fonts is not None
+
+
+def test_fonts_with_paths():
+    fonts = typst.Fonts(font_paths=["/usr/share/fonts"])
+    assert fonts is not None
+
+
+def test_compile_with_fonts_object(hello_typ_path):
+    fonts = typst.Fonts(include_system_fonts=True)
+    result = typst.compile(hello_typ_path, font_paths=fonts, format="pdf")
+    assert isinstance(result, bytes)
+    assert result.startswith(b"%PDF-")
+
+
+# Font discovery methods tests
+def test_fonts_families():
+    fonts_obj = typst.Fonts()
+    families = fonts_obj.families()
+    assert isinstance(families, list)
+    assert len(families) > 0
+    assert all(isinstance(f, str) for f in families)
+
+
+def test_fonts_fonts_returns_list():
+    fonts_obj = typst.Fonts()
+    fonts_list = fonts_obj.fonts()
+    assert isinstance(fonts_list, list)
+    assert len(fonts_list) > 0
+
+
+def test_font_info_attributes():
+    fonts_obj = typst.Fonts()
+    fonts_list = fonts_obj.fonts()
+    font = fonts_list[0]
+
+    assert isinstance(font.family, str)
+    assert font.style in ("normal", "italic", "oblique")
+    assert isinstance(font.weight, int)
+    assert 100 <= font.weight <= 900
+    assert isinstance(font.stretch, float)
+    assert font.path is None or isinstance(font.path, str)
+    assert isinstance(font.index, int)
+
+
+def test_fonts_no_system_fonts_families():
+    fonts_obj = typst.Fonts(include_system_fonts=False)
+    families = fonts_obj.families()
+    assert isinstance(families, list)
+
+
+def test_fonts_no_embedded_fonts_families():
+    fonts_obj = typst.Fonts(include_embedded_fonts=False)
+    families = fonts_obj.families()
+    assert isinstance(families, list)
+
+
+def test_fonts_embedded_only():
+    fonts_obj = typst.Fonts(include_system_fonts=False, include_embedded_fonts=True)
+    fonts_list = fonts_obj.fonts()
+    assert isinstance(fonts_list, list)
+    assert len(fonts_list) > 0
+    for font in fonts_list:
+        assert font.path is None
+
+
+def test_font_info_repr():
+    fonts_obj = typst.Fonts()
+    fonts_list = fonts_obj.fonts()
+    font = fonts_list[0]
+    repr_str = repr(font)
+    assert "FontInfo" in repr_str
+    assert font.family in repr_str

--- a/tests/test_typst.py
+++ b/tests/test_typst.py
@@ -51,14 +51,14 @@ def test_compile_to_png_bytes(hello_typ_path):
 def test_compile_from_string_content():
     # String content needs to be passed as bytes for direct compilation
     content = "= Hello\nThis is a test document."
-    result = typst.compile(content.encode('utf-8'), format="pdf")
+    result = typst.compile(content.encode("utf-8"), format="pdf")
     assert isinstance(result, bytes)
     assert result.startswith(b"%PDF-")
 
 
 def test_compile_from_bytes_content():
     content = "= Hello\nThis is a test document."
-    content_bytes = content.encode('utf-8')
+    content_bytes = content.encode("utf-8")
     result = typst.compile(content_bytes, format="pdf")
     assert isinstance(result, bytes)
     assert result.startswith(b"%PDF-")
@@ -202,7 +202,9 @@ def test_compiler_compile_sys_inputs_dict_updates():
     result_initial = compiler.compile(input=source, format="pdf")
 
     # Compile with new sys_inputs dict
-    result_updated = compiler.compile(input=source, format="pdf", sys_inputs={"name": "updated"})
+    result_updated = compiler.compile(
+        input=source, format="pdf", sys_inputs={"name": "updated"}
+    )
 
     # Results should differ since sys_inputs changed
     assert result_initial != result_updated
@@ -214,7 +216,9 @@ def test_compiler_compile_sys_inputs_persists_after_update():
     compiler = typst.Compiler(source, sys_inputs={"name": "initial"})
 
     # Update sys_inputs
-    result_updated = compiler.compile(input=source, format="pdf", sys_inputs={"name": "updated"})
+    result_updated = compiler.compile(
+        input=source, format="pdf", sys_inputs={"name": "updated"}
+    )
 
     # Next compile with Ellipsis (default) should keep updated value
     result_persisted = compiler.compile(input=source, format="pdf")
@@ -244,12 +248,16 @@ def test_compiler_compile_with_warnings_sys_inputs():
     compiler = typst.Compiler(source, sys_inputs={"name": "initial"})
 
     # Compile with warnings and new sys_inputs
-    result, warnings = compiler.compile_with_warnings(input=source, format="pdf", sys_inputs={"name": "updated"})
+    result, warnings = compiler.compile_with_warnings(
+        input=source, format="pdf", sys_inputs={"name": "updated"}
+    )
     assert isinstance(result, bytes)
     assert isinstance(warnings, list)
 
     # Compile with warnings and None (clear)
-    result_cleared, warnings = compiler.compile_with_warnings(input=source, format="pdf", sys_inputs=None)
+    result_cleared, warnings = compiler.compile_with_warnings(
+        input=source, format="pdf", sys_inputs=None
+    )
     assert isinstance(result_cleared, bytes)
     assert result != result_cleared
 
@@ -284,7 +292,9 @@ def test_query_with_field(hello_typ_path):
 
 def test_query_one_element(hello_typ_path):
     # Query for a specific heading that should be unique
-    result = typst.query(hello_typ_path, "heading.where(level: 1)", one=True, format="json")
+    result = typst.query(
+        hello_typ_path, "heading.where(level: 1)", one=True, format="json"
+    )
     data = json.loads(result)
     assert not isinstance(data, list)
 
@@ -302,38 +312,9 @@ def test_compiler_query(hello_typ_path):
     assert isinstance(data, list)
 
 
-# Fonts tests
-def test_fonts_default():
-    fonts = typst.Fonts()
-    assert fonts is not None
-
-
-def test_fonts_no_system_fonts():
-    fonts = typst.Fonts(include_system_fonts=False)
-    assert fonts is not None
-
-
-def test_fonts_no_embedded_fonts():
-    fonts = typst.Fonts(include_embedded_fonts=False)
-    assert fonts is not None
-
-
-def test_fonts_with_paths():
-    fonts = typst.Fonts(font_paths=["/usr/share/fonts"])
-    assert fonts is not None
-
-
-def test_compile_with_fonts_object():
-    fonts = typst.Fonts(include_system_fonts=True)
-    hello_typ = pathlib.Path("tests/hello.typ")
-    result = typst.compile(hello_typ, font_paths=fonts, format="pdf")
-    assert isinstance(result, bytes)
-    assert result.startswith(b"%PDF-")
-
-
 # Error handling tests
 def test_invalid_syntax_raises_typst_error():
-    broken_content  = b"#invalid syntax here"
+    broken_content = b"#invalid syntax here"
 
     with pytest.raises(typst.TypstError) as exc_info:
         typst.compile(broken_content, format="pdf")
@@ -403,7 +384,7 @@ def test_all_formats(format_name, use_file, tmp_path):
 def test_unsupported_format():
     # Test with an invalid format parameter
     simple_content = "= Hello\nThis is a simple document."
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.typ', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".typ", delete=False) as f:
         f.write(simple_content)
         temp_path = pathlib.Path(f.name)
 
@@ -418,7 +399,7 @@ def test_unsupported_format():
 
 # Edge cases tests
 def test_empty_document():
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.typ', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".typ", delete=False) as f:
         f.write("")
         temp_path = pathlib.Path(f.name)
 
@@ -432,7 +413,9 @@ def test_empty_document():
 
 def test_unicode_content():
     unicode_content = "= 测试\n这是一个中文文档 🎉"
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.typ', delete=False, encoding='utf-8') as f:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".typ", delete=False, encoding="utf-8"
+    ) as f:
         f.write(unicode_content)
         temp_path = pathlib.Path(f.name)
 
@@ -445,8 +428,10 @@ def test_unicode_content():
 
 
 def test_large_document():
-    large_content = "= Large Document\n" + "This is a paragraph.\n" * 100  # Reduced size
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.typ', delete=False) as f:
+    large_content = (
+        "= Large Document\n" + "This is a paragraph.\n" * 100
+    )  # Reduced size
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".typ", delete=False) as f:
         f.write(large_content)
         temp_path = pathlib.Path(f.name)
 
@@ -464,7 +449,7 @@ $ sum_(i=1)^n i = (n(n+1))/2 $
 $ integral_0^infinity e^(-x^2) dif x = sqrt(pi)/2 $
 $ lim_(x->0) (sin x)/x = 1 $
 """
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.typ', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".typ", delete=False) as f:
         f.write(math_content)
         temp_path = pathlib.Path(f.name)
 
@@ -521,7 +506,7 @@ def test_compile_with_all_options(hello_typ_path):
             output=output_path,
             format="pdf",
             font_paths=fonts,
-            sys_inputs={"test": "value"}
+            sys_inputs={"test": "value"},
         )
         assert result is None
         assert output_path.exists()


### PR DESCRIPTION
## Summary

This PR enhances existing `Fonts` class with font discovery capabilities and introduces a new `FontInfo` class.

## Changes

### Enhancements to `Fonts` class
- Added `fonts()` method to return a list of all available font variants as `FontInfo` objects
- Added `families()` method to return a sorted list of unique font family names

### New `FontInfo` class
- Immutable class representing font metadata
- Attributes: `family`, `style`, `weight`, `stretch`, `path`, `index`
- Provides detailed information about each font variant found on system

### Code improvements
- Exported `FontInfo` from `typst` module (`typst.FontInfo`)
- Organized font-related tests into dedicated `tests/test_fonts.py`
- Fixed clippy warnings

## API Usage

```python
import typst

# Font discovery
fonts_obj = typst.Fonts()
families = fonts_obj.families()      # List[str] - unique font family names
font_list = fonts_obj.fonts()        # List[FontInfo] - all font variants

# Access font information
font = font_list[0]
print(f"Family: {font.family}, Style: {font.style}, Weight: {font.weight}")

# Compilation (unchanged)
typst.compile("doc.typ", font_paths=fonts_obj)
```