### PR TITLE
Adds description to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dynamic = ["version"]
 dependencies = []
 license = "Apache-2.0"
 license-files = ["LICENSE"]
+description = "Python binding to Typst, a new markup-based typesetting system that is powerful and easy to learn."
 readme = "README.md"
 
 [project.urls]


### PR DESCRIPTION
The `description` field will show in https://pypi.org/search/?q=typst and https://pypi.org/project/typst/.
At present, it's _None_ or _No project description provided_.

<img width="300" alt="图片" src="https://github.com/user-attachments/assets/1cb4da00-ac20-4057-9957-b0224e012add" />
<img width="300" alt="图片" src="https://github.com/user-attachments/assets/8cae90e2-e0f2-48d2-ac40-ee8c5c35575f" />

> [**description** - Writing your pyproject.toml - Python Packaging User Guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#description):
>
> This should be a one-line description of your project, to show as the “headline” of your project page on PyPI ([example](https://pypi.org/project/pip)), and other places such as lists of search results ([example](https://pypi.org/search?q=pip)).

The description added in this PR is copied from the README.

https://github.com/messense/typst-py/blob/f759b8f52a546b6bf39c098d194e46ba9ed21c5b/README.md?plain=1#L7-L8

Continues #132