### PR TITLE
feat: Add reproducible pdf timestamp option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,6 +1846,7 @@ version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
+ "chrono",
  "libc",
  "once_cell",
  "portable-atomic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ codespan-reporting = "0.13"
 comemo = "0.5.1"
 ecow = "0.2"
 pathdiff = "0.2"
-pyo3 = { version = "0.28.3", features = ["abi3-py38", "generate-import-lib"] }
+pyo3 = { version = "0.28.3", features = ["abi3-py38", "chrono", "generate-import-lib"] }
 rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pip install typst
 ## Usage
 
 ```python
+import datetime
 import typst
 
 
@@ -31,6 +32,10 @@ with open("hello.typ", "rb") as f:
 
 # Or return PDF content as bytes
 pdf_bytes = typst.compile("hello.typ")
+
+# Use a fixed creation timestamp for reproducible PDFs
+timestamp = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
+pdf_bytes = typst.compile("hello.typ", timestamp=timestamp)
 
 # Also for svg
 svg_bytes = typst.compile("hello.typ", format="svg")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Usage
 
 .. code-block:: python
 
+    import datetime
     import typst
 
 
@@ -31,6 +32,10 @@ Usage
 
     # Or return PDF content as bytes
     pdf_bytes = typst.compile("hello.typ")
+
+    # Use a fixed creation timestamp for reproducible PDFs
+    timestamp = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
+    pdf_bytes = typst.compile("hello.typ", timestamp=timestamp)
 
     # Also for svg
     svg_bytes = typst.compile("hello.typ", format="svg")

--- a/python/typst/__init__.pyi
+++ b/python/typst/__init__.pyi
@@ -1,3 +1,4 @@
+import datetime
 import pathlib
 from types import EllipsisType
 from typing import List, Optional, TypeVar, overload, Dict, Union, Literal, Tuple
@@ -5,6 +6,7 @@ from typing import List, Optional, TypeVar, overload, Dict, Union, Literal, Tupl
 Input = TypeVar("Input", str, pathlib.Path, bytes)
 OutputFormat = Literal["pdf", "svg", "png", "html"]
 PathLike = TypeVar("PathLike", str, pathlib.Path)
+CreationTimestamp = Union[int, datetime.datetime]
 
 class TypstError(RuntimeError):
     """A structured error raised during Typst compilation or querying.
@@ -112,6 +114,7 @@ class Compiler:
             Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]
         ] = [],
         root: Optional[PathLike] = None,
+        timestamp: Optional[CreationTimestamp] = None,
     ) -> Optional[Union[bytes, List[bytes]]]:
         """Compile a Typst project.
         Args:
@@ -128,6 +131,7 @@ class Compiler:
             pdf_standards (Optional[Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]]):
                 One or more PDF standard profiles to apply when exporting.
             root (Optional[PathLike]): Override the root path for this compilation.
+            timestamp (Optional[CreationTimestamp]): Creation timestamp as timezone-aware fixed-offset datetime.datetime or UNIX seconds, equivalent to SOURCE_DATE_EPOCH.
         Returns:
             Optional[Union[bytes, List[bytes]]]: Return the compiled file as `bytes` if output is `None`.
         """
@@ -143,6 +147,7 @@ class Compiler:
             Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]
         ] = [],
         root: Optional[PathLike] = None,
+        timestamp: Optional[CreationTimestamp] = None,
     ) -> Tuple[Optional[Union[bytes, List[bytes]]], List[TypstWarning]]:
         """Compile a Typst project and return both result and warnings.
         Args:
@@ -159,6 +164,7 @@ class Compiler:
             pdf_standards (Optional[Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]]):
                 One or more PDF standard profiles to apply when exporting.
             root (Optional[PathLike]): Override the root path for this compilation.
+            timestamp (Optional[CreationTimestamp]): Creation timestamp as timezone-aware fixed-offset datetime.datetime or UNIX seconds, equivalent to SOURCE_DATE_EPOCH.
         Returns:
             Tuple[Optional[Union[bytes, List[bytes]]], List[TypstWarning]]: Return a tuple of (compiled_data, warnings).
             The first element is the compiled file as `bytes` if output is `None`, otherwise `None`.
@@ -198,6 +204,7 @@ def compile(
         Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]
     ] = [],
     package_path: Optional[PathLike] = None,
+    timestamp: Optional[CreationTimestamp] = None,
 ) -> None: ...
 @overload
 def compile(
@@ -213,6 +220,7 @@ def compile(
         Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]
     ] = [],
     package_path: Optional[PathLike] = None,
+    timestamp: Optional[CreationTimestamp] = None,
 ) -> bytes: ...
 def compile(
     input: Input,
@@ -227,6 +235,7 @@ def compile(
         Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]
     ] = [],
     package_path: Optional[PathLike] = None,
+    timestamp: Optional[CreationTimestamp] = None,
 ) -> Optional[Union[bytes, List[bytes]]]:
     """Compile a Typst project.
     Args:
@@ -243,6 +252,7 @@ def compile(
         pdf_standards (Optional[Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]]):
         One or more PDF standard profiles to apply when exporting. Allowed values are `1.7`, `a-2b`, `a-3b`.
         package_path (Optional[PathLike]): Path to load local packages from.
+        timestamp (Optional[CreationTimestamp]): Creation timestamp as timezone-aware fixed-offset datetime.datetime or UNIX seconds, equivalent to SOURCE_DATE_EPOCH.
     Returns:
         Optional[Union[bytes, List[bytes]]]: Return the compiled file as `bytes` if output is `None`.
     """
@@ -261,6 +271,7 @@ def compile_with_warnings(
         Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]
     ] = [],
     package_path: Optional[PathLike] = None,
+    timestamp: Optional[CreationTimestamp] = None,
 ) -> Tuple[None, List[TypstWarning]]: ...
 @overload
 def compile_with_warnings(
@@ -276,6 +287,7 @@ def compile_with_warnings(
         Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]
     ] = [],
     package_path: Optional[PathLike] = None,
+    timestamp: Optional[CreationTimestamp] = None,
 ) -> Tuple[bytes, List[TypstWarning]]: ...
 def compile_with_warnings(
     input: Input,
@@ -290,6 +302,7 @@ def compile_with_warnings(
         Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]
     ] = [],
     package_path: Optional[PathLike] = None,
+    timestamp: Optional[CreationTimestamp] = None,
 ) -> Tuple[Optional[Union[bytes, List[bytes]]], List[TypstWarning]]:
     """Compile a Typst project and return warnings.
     Args:
@@ -306,6 +319,7 @@ def compile_with_warnings(
         pdf_standards (Optional[Union[Literal["1.7", "a-2b", "a-3b"], List[Literal["1.7", "a-2b", "a-3b"]]]]):
         One or more PDF standard profiles to apply when exporting. Allowed values are `1.7`, `a-2b`, `a-3b`.
         package_path (Optional[PathLike]): Path to load local packages from.
+        timestamp (Optional[CreationTimestamp]): Creation timestamp as timezone-aware fixed-offset datetime.datetime or UNIX seconds, equivalent to SOURCE_DATE_EPOCH.
     Returns:
         Optional[Union[bytes, List[bytes]]]: Return the compiled file as `bytes` if output is `None`.
     """

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -9,7 +9,7 @@ use typst::layout::PagedDocument;
 use typst::syntax::{FileId, Lines, Span};
 use typst_html::HtmlDocument;
 
-use crate::world::SystemWorld;
+use crate::{CreationTimestamp, world::SystemWorld};
 
 type CodespanResult<T> = Result<T, CodespanError>;
 type CodespanError = codespan_reporting::files::Error;
@@ -24,14 +24,22 @@ impl SystemWorld {
         format: Option<&str>,
         ppi: Option<f32>,
         pdf_standards: &[typst_pdf::PdfStandard],
+        creation_timestamp: Option<&CreationTimestamp>,
     ) -> Result<CompileSuccess, CompileError> {
+        if let Some(creation_timestamp) = creation_timestamp {
+            self.set_now(creation_timestamp.local());
+        }
+
         let normalized_format = format.unwrap_or("pdf").to_ascii_lowercase();
 
         let Warned { output, warnings } = match normalized_format.as_str() {
             "html" => self.compile_and_export_html(),
-            "pdf" | "png" | "svg" => {
-                self.compile_and_export_paged(normalized_format.as_str(), ppi, pdf_standards)
-            }
+            "pdf" | "png" | "svg" => self.compile_and_export_paged(
+                normalized_format.as_str(),
+                ppi,
+                pdf_standards,
+                creation_timestamp,
+            ),
             _ => return Err((vec![], vec![])),
         };
 
@@ -47,6 +55,7 @@ impl SystemWorld {
         format: &str,
         ppi: Option<f32>,
         pdf_standards: &[typst_pdf::PdfStandard],
+        creation_timestamp: Option<&CreationTimestamp>,
     ) -> Warned<SourceResult<Vec<Vec<u8>>>> {
         let Warned { output, warnings } = typst::compile::<PagedDocument>(self);
         // Evict comemo cache to limit memory usage after compilation
@@ -57,7 +66,7 @@ impl SystemWorld {
                 let standards = typst_pdf::PdfStandards::new(pdf_standards)
                     .map_err(|e| eco_format!("PDF standards error: {:?}", e))
                     .at(Span::detached())?;
-                export_pdf(&document, self, standards).map(|pdf| vec![pdf])
+                export_pdf(&document, self, standards, creation_timestamp).map(|pdf| vec![pdf])
             }
             "png" => export_image(&document, ImageExportFormat::Png, ppi).at(Span::detached()),
             "svg" => export_image(&document, ImageExportFormat::Svg, ppi).at(Span::detached()),
@@ -99,12 +108,17 @@ fn export_pdf(
     document: &PagedDocument,
     _world: &SystemWorld,
     standards: typst_pdf::PdfStandards,
+    creation_timestamp: Option<&CreationTimestamp>,
 ) -> SourceResult<Vec<u8>> {
+    let timestamp = creation_timestamp
+        .map(CreationTimestamp::pdf)
+        .or_else(|| now().map(typst_pdf::Timestamp::new_utc));
+
     let buffer = typst_pdf::pdf(
         document,
         &typst_pdf::PdfOptions {
             ident: typst::foundations::Smart::Auto,
-            timestamp: now().map(typst_pdf::Timestamp::new_utc),
+            timestamp,
             standards,
             ..Default::default()
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,15 @@
 use std::{env, path::PathBuf, sync::Arc};
 
+use chrono::{DateTime, Datelike, FixedOffset, Local, Timelike, Utc};
 use pyo3::create_exception;
-use pyo3::exceptions::{PyRuntimeError, PyUserWarning, PyValueError};
+use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyUserWarning, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyList, PyString, PyTuple};
+use pyo3::types::{PyBytes, PyDateTime, PyList, PyString, PyTuple};
 
 use query::{QueryCommand, SerializationFormat, query as typst_query};
 use std::collections::HashMap;
 use typst::diag::SourceDiagnostic;
-use typst::foundations::{Dict, Value};
+use typst::foundations::{Datetime, Dict, Value};
 use typst::text::FontStyle;
 use world::SystemWorld;
 
@@ -85,6 +86,79 @@ impl TypstDiagnosticDetails {
 pub struct CompilationResult {
     pub data: Vec<Vec<u8>>,
     pub warnings: Vec<TypstDiagnosticDetails>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CreationTimestamp {
+    utc: DateTime<Utc>,
+}
+
+impl CreationTimestamp {
+    fn from_unix(timestamp: i64) -> PyResult<Self> {
+        let utc = DateTime::from_timestamp(timestamp, 0).ok_or_else(invalid_timestamp)?;
+        Self::from_utc(utc)
+    }
+
+    fn from_utc(utc: DateTime<Utc>) -> PyResult<Self> {
+        datetime_from_utc(&utc).ok_or_else(invalid_timestamp)?;
+        Ok(Self { utc })
+    }
+
+    fn from_py_datetime(datetime: DateTime<FixedOffset>) -> PyResult<Self> {
+        if datetime.timestamp_subsec_micros() != 0 {
+            return Err(PyValueError::new_err(
+                "timestamp datetime must not include microseconds",
+            ));
+        }
+
+        Self::from_utc(datetime.with_timezone(&Utc))
+    }
+
+    pub(crate) fn pdf(&self) -> typst_pdf::Timestamp {
+        let datetime =
+            datetime_from_utc(&self.utc).expect("creation timestamp is validated on construction");
+        typst_pdf::Timestamp::new_utc(datetime)
+    }
+
+    pub(crate) fn local(&self) -> DateTime<Local> {
+        self.utc.with_timezone(&Local)
+    }
+}
+
+fn datetime_from_utc(utc: &DateTime<Utc>) -> Option<Datetime> {
+    Datetime::from_ymd_hms(
+        utc.year(),
+        utc.month().try_into().ok()?,
+        utc.day().try_into().ok()?,
+        utc.hour().try_into().ok()?,
+        utc.minute().try_into().ok()?,
+        utc.second().try_into().ok()?,
+    )
+}
+
+fn invalid_timestamp() -> PyErr {
+    PyValueError::new_err("timestamp is out of range")
+}
+
+fn extract_creation_timestamp(obj: &Bound<'_, PyAny>) -> PyResult<Option<CreationTimestamp>> {
+    if obj.is_none() {
+        return Ok(None);
+    }
+
+    if let Ok(timestamp) = obj.extract::<i64>() {
+        return CreationTimestamp::from_unix(timestamp).map(Some);
+    }
+
+    if obj.cast::<PyDateTime>().is_ok() {
+        let datetime = obj.extract::<DateTime<FixedOffset>>().map_err(|_| {
+            PyValueError::new_err("timestamp datetime must be timezone-aware with a fixed offset")
+        })?;
+        return CreationTimestamp::from_py_datetime(datetime).map(Some);
+    }
+
+    Err(PyTypeError::new_err(
+        "timestamp must be None, an int UNIX timestamp, or datetime.datetime",
+    ))
 }
 
 mod output_template {
@@ -411,11 +485,14 @@ impl Compiler {
         format: Option<&str>,
         ppi: Option<f32>,
         pdf_standards: &[typst_pdf::PdfStandard],
+        creation_timestamp: Option<&CreationTimestamp>,
     ) -> Result<Vec<Vec<u8>>, TypstDiagnosticDetails> {
-        let ret = match self
-            .world
-            .compile_with_diagnostics(format, ppi, pdf_standards)
-        {
+        let ret = match self.world.compile_with_diagnostics(
+            format,
+            ppi,
+            pdf_standards,
+            creation_timestamp,
+        ) {
             Ok((buffer, _warnings)) => Ok(buffer), // Ignore warnings for backward compatibility
             Err((errors, warnings)) => Err(create_typst_diagnostic_details(
                 &self.world,
@@ -433,11 +510,14 @@ impl Compiler {
         format: Option<&str>,
         ppi: Option<f32>,
         pdf_standards: &[typst_pdf::PdfStandard],
+        creation_timestamp: Option<&CreationTimestamp>,
     ) -> Result<CompilationResult, TypstDiagnosticDetails> {
-        let ret = match self
-            .world
-            .compile_with_diagnostics(format, ppi, pdf_standards)
-        {
+        let ret = match self.world.compile_with_diagnostics(
+            format,
+            ppi,
+            pdf_standards,
+            creation_timestamp,
+        ) {
             Ok((buffer, warnings)) => {
                 let warning_details =
                     create_typst_warning_details_from_diagnostics(&self.world, &warnings);
@@ -543,7 +623,7 @@ impl Compiler {
 
     /// Compile a typst file to PDF
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(name = "compile", signature = (input = None, output = None, format = None, ppi = None, sys_inputs = SysInputsOption::Keep, pdf_standards = Vec::new(), root = None))]
+    #[pyo3(name = "compile", signature = (input = None, output = None, format = None, ppi = None, sys_inputs = SysInputsOption::Keep, pdf_standards = Vec::new(), root = None, timestamp = None))]
     fn py_compile(
         &mut self,
         py: Python<'_>,
@@ -554,6 +634,7 @@ impl Compiler {
         #[pyo3(from_py_with = extract_sys_inputs_option)] sys_inputs: SysInputsOption,
         #[pyo3(from_py_with = extract_pdf_standards)] pdf_standards: Vec<typst_pdf::PdfStandard>,
         root: Option<PathBuf>,
+        #[pyo3(from_py_with = extract_creation_timestamp)] timestamp: Option<CreationTimestamp>,
     ) -> PyResult<Py<PyAny>> {
         self.apply_root(root)?;
         self.apply_input(input)?;
@@ -580,7 +661,7 @@ impl Compiler {
             };
 
             let buffers = py
-                .detach(|| self.compile(format, ppi, &pdf_standards))
+                .detach(|| self.compile(format, ppi, &pdf_standards, timestamp.as_ref()))
                 .map_err(|err_details| err_details.into_py_err(py).unwrap())?;
 
             let can_handle_multiple =
@@ -604,7 +685,7 @@ impl Compiler {
             Ok(py.None())
         } else {
             let buffers = py
-                .detach(|| self.compile(format, ppi, &pdf_standards))
+                .detach(|| self.compile(format, ppi, &pdf_standards, timestamp.as_ref()))
                 .map_err(|err_details| err_details.into_py_err(py).unwrap())?;
             if buffers.len() == 1 {
                 // Return a single buffer as a single byte string
@@ -621,7 +702,7 @@ impl Compiler {
 
     /// Compile a typst file and return both result and warnings
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(name = "compile_with_warnings", signature = (input = None, output = None, format = None, ppi = None, sys_inputs = SysInputsOption::Keep, pdf_standards = Vec::new(), root = None))]
+    #[pyo3(name = "compile_with_warnings", signature = (input = None, output = None, format = None, ppi = None, sys_inputs = SysInputsOption::Keep, pdf_standards = Vec::new(), root = None, timestamp = None))]
     fn py_compile_with_warnings(
         &mut self,
         py: Python<'_>,
@@ -632,12 +713,13 @@ impl Compiler {
         #[pyo3(from_py_with = extract_sys_inputs_option)] sys_inputs: SysInputsOption,
         #[pyo3(from_py_with = extract_pdf_standards)] pdf_standards: Vec<typst_pdf::PdfStandard>,
         root: Option<PathBuf>,
+        #[pyo3(from_py_with = extract_creation_timestamp)] timestamp: Option<CreationTimestamp>,
     ) -> PyResult<Py<PyAny>> {
         self.apply_root(root)?;
         self.apply_input(input)?;
         self.apply_sys_inputs(sys_inputs);
         let result = py
-            .detach(|| self.compile_with_warnings(format, ppi, &pdf_standards))
+            .detach(|| self.compile_with_warnings(format, ppi, &pdf_standards, timestamp.as_ref()))
             .map_err(|err_details| err_details.into_py_err(py).unwrap())?;
 
         // Convert warnings to Python objects
@@ -714,7 +796,8 @@ impl Compiler {
     format = None, ppi = None,
     sys_inputs = HashMap::new(),
     pdf_standards = Vec::new(),
-    package_path=None,
+    package_path = None,
+    timestamp = None,
 ))]
 #[allow(clippy::too_many_arguments)]
 fn compile(
@@ -729,6 +812,7 @@ fn compile(
     sys_inputs: HashMap<String, String>,
     #[pyo3(from_py_with = extract_pdf_standards)] pdf_standards: Vec<typst_pdf::PdfStandard>,
     package_path: Option<PathBuf>,
+    #[pyo3(from_py_with = extract_creation_timestamp)] timestamp: Option<CreationTimestamp>,
 ) -> PyResult<Py<PyAny>> {
     let mut compiler = Compiler::new(
         Some(input),
@@ -747,6 +831,7 @@ fn compile(
         SysInputsOption::Keep,
         pdf_standards,
         None,
+        timestamp,
     )
 }
 
@@ -761,7 +846,8 @@ fn compile(
     format = None, ppi = None,
     sys_inputs = HashMap::new(),
     pdf_standards = Vec::new(),
-    package_path=None
+    package_path = None,
+    timestamp = None,
 ))]
 #[allow(clippy::too_many_arguments)]
 fn compile_with_warnings(
@@ -776,6 +862,7 @@ fn compile_with_warnings(
     sys_inputs: HashMap<String, String>,
     #[pyo3(from_py_with = extract_pdf_standards)] pdf_standards: Vec<typst_pdf::PdfStandard>,
     package_path: Option<PathBuf>,
+    #[pyo3(from_py_with = extract_creation_timestamp)] timestamp: Option<CreationTimestamp>,
 ) -> PyResult<Py<PyAny>> {
     let mut compiler = Compiler::new(
         Some(input),
@@ -794,6 +881,7 @@ fn compile_with_warnings(
         SysInputsOption::Keep,
         pdf_standards,
         None,
+        timestamp,
     )
 }
 
@@ -811,7 +899,7 @@ fn compile_with_warnings(
         font_paths = FontsOrPaths::Paths(Vec::new()),
         ignore_system_fonts = false,
         sys_inputs = HashMap::new(),
-        package_path=None,
+        package_path = None,
     )
 )]
 #[allow(clippy::too_many_arguments)]

--- a/src/world.rs
+++ b/src/world.rs
@@ -17,7 +17,7 @@ use typst_kit::{
     package::PackageStorage,
 };
 
-use crate::{Input, FileData, download::SlientDownload};
+use crate::{FileData, Input, download::SlientDownload};
 
 /// A world that provides access to the operating system.
 pub struct SystemWorld {
@@ -111,6 +111,11 @@ impl SystemWorld {
         self.now.take();
     }
 
+    pub(crate) fn set_now(&mut self, now: DateTime<Local>) {
+        self.now.take();
+        let _ = self.now.set(now);
+    }
+
     /// Update the sys_inputs for the world.
     pub fn set_inputs(&mut self, inputs: Dict) {
         self.library = LazyHash::new(
@@ -177,7 +182,10 @@ fn determine_main_filename(files: &HashMap<String, FileData>) -> StrResult<&str>
     } else if files.len() == 1 {
         Ok(files.keys().next().unwrap())
     } else {
-        Err("Could not determine main file: use 'main' or 'main.typ' as key, or pass a single file".into())
+        Err(
+            "Could not determine main file: use 'main' or 'main.typ' as key, or pass a single file"
+                .into(),
+        )
     }
 }
 
@@ -192,9 +200,9 @@ fn process_files_into_slots(
         let bytes = match file_data {
             FileData::Bytes(b) => b.clone(),
             FileData::Path(path) => {
-                let path = path
-                    .canonicalize()
-                    .map_err(|err| format!("Failed to canonicalize path for {}: {}", filename, err))?;
+                let path = path.canonicalize().map_err(|err| {
+                    format!("Failed to canonicalize path for {}: {}", filename, err)
+                })?;
                 std::fs::read(&path)
                     .map_err(|err| format!("Failed to read file {}: {}", filename, err))?
             }
@@ -203,8 +211,7 @@ fn process_files_into_slots(
         let vpath = VirtualPath::new(format!("/{}", filename));
         let file_id = FileId::new(None, vpath);
 
-        let slot = FileSlot::from_inline_bytes(file_id, bytes)
-            .map_err(|err| err.to_string())?;
+        let slot = FileSlot::from_inline_bytes(file_id, bytes).map_err(|err| err.to_string())?;
         slots.insert(file_id, slot);
 
         if filename == main_filename {
@@ -404,7 +411,7 @@ impl SystemWorld {
         self.slots.lock().unwrap().insert(id, slot);
         Ok(())
     }
-    
+
     fn configure_files_input(&mut self, files: HashMap<String, FileData>) -> StrResult<()> {
         let main_filename = determine_main_filename(&files)?;
 

--- a/tests/test_typst.py
+++ b/tests/test_typst.py
@@ -1,3 +1,4 @@
+import datetime
 import pytest
 import pathlib
 import tempfile
@@ -28,6 +29,48 @@ def test_compile_to_pdf_bytes(hello_typ_path):
     result = typst.compile(hello_typ_path, format="pdf")
     assert isinstance(result, bytes)
     assert result.startswith(b"%PDF-")
+
+
+def test_compile_to_pdf_with_timestamp_is_reproducible():
+    source = b"Rendered on #datetime.today(offset: 0).display()"
+
+    first = typst.compile(source, format="pdf", timestamp=0)
+    second = typst.compile(source, format="pdf", timestamp=0)
+    different_day = typst.compile(source, format="pdf", timestamp=86_400)
+
+    assert isinstance(first, bytes)
+    assert first.startswith(b"%PDF-")
+    assert first == second
+    assert first != different_day
+
+
+def test_compile_to_pdf_with_datetime_timestamp_is_reproducible():
+    source = b"Rendered on #datetime.today(offset: 0).display()"
+    timestamp = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
+
+    from_datetime = typst.compile(source, format="pdf", timestamp=timestamp)
+    from_epoch = typst.compile(source, format="pdf", timestamp=0)
+
+    assert isinstance(from_datetime, bytes)
+    assert from_datetime == from_epoch
+
+
+def test_compile_to_pdf_with_subsecond_datetime_timestamp_raises():
+    source = b"= Hello"
+    timestamp = datetime.datetime(
+        2023, 11, 14, 22, 13, 20, 1, tzinfo=datetime.timezone.utc
+    )
+
+    with pytest.raises(ValueError, match="must not include microseconds"):
+        typst.compile(source, format="pdf", timestamp=timestamp)
+
+
+def test_compile_to_pdf_with_naive_datetime_timestamp_raises():
+    source = b"= Hello"
+    timestamp = datetime.datetime(2023, 11, 14, 22, 13, 20)
+
+    with pytest.raises(ValueError, match="must be timezone-aware"):
+        typst.compile(source, format="pdf", timestamp=timestamp)
 
 
 def test_compile_to_svg_bytes(hello_typ_path):


### PR DESCRIPTION
## Motivation

We want to build reproducible PDFs with typst in a CI pipeline. The Typst CLI supports this use case by setting the `SOURCE_DATE_EPOCH` environment variable or by passing the `--creation-timestamp` CLI argument.

This library currently does not support setting the creation timestamp and uses the current time.

## Changes

- Add a `timestamp` compile option for reproducible PDF creation timestamps.
- Accept timezone-aware `datetime.datetime` values and integer Unix timestamps.
- Seed Typst's compilation clock so rendered `datetime.today()` output and PDF metadata are reproducible together.

I also formatted with `cargo fmt --check`.

## AI Note

Codex assisted me in creating this PR, but I reviewed it manually.